### PR TITLE
Add support for the new tramp syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - EMACS_VERSION=24.3
   - EMACS_VERSION=24.4
   - EMACS_VERSION=24.5
+  - EMACS_VERSION=25.1
+  - EMACS_VERSION=25.2
   - EMACS_VERSION=snapshot
 matrix:
   allow_failures:

--- a/sudo-edit.el
+++ b/sudo-edit.el
@@ -123,8 +123,8 @@ attention to case differences."
                    (tramp-file-name-host vec)
                    ""
                    (tramp-file-name-hop vec))))
-        (setq hop (string-remove-prefix tramp-prefix-format hop))
-        (setq hop (string-remove-suffix tramp-postfix-host-format hop))
+        (setq hop (string-remove-prefix (if (fboundp 'tramp-prefix-format) (tramp-prefix-format) (bound-and-true-p tramp-prefix-format)) hop))
+        (setq hop (string-remove-suffix (if (fboundp 'tramp-postfix-host-format) (tramp-postfix-host-format) (bound-and-true-p tramp-postfix-host-format)) hop))
         (setq hop (concat hop tramp-postfix-hop-format))
         (if (and (string= user (tramp-file-name-user vec))
                  (string-match tramp-local-host-regexp (tramp-file-name-host vec)))

--- a/sudo-edit.el
+++ b/sudo-edit.el
@@ -140,7 +140,7 @@ With a prefix ARG prompt for a file to visit.  Will also prompt
 for a file to visit if current buffer is not visiting a file."
   (interactive "P")
   (let ((user (if arg
-                  (completing-read "User: " (system-users) nil nil nil 'sudo-edit-user-history sudo-edit-user)
+                  (completing-read "User: " (and (fboundp 'system-users) (system-users)) nil nil nil 'sudo-edit-user-history sudo-edit-user)
                 sudo-edit-user))
         (filename (or buffer-file-name
                       (and (derived-mode-p 'dired-mode) default-directory))))


### PR DESCRIPTION
Recently TRAMP changed the way its syntax. See: https://git.savannah.gnu.org/cgit/tramp.git/commit/?id=cdc3b249f13996ea4d1f7377a46bf0a18c10dd8b