### PR TITLE
add sudo-edit-find-file command

### DIFF
--- a/sudo-edit.el
+++ b/sudo-edit.el
@@ -202,6 +202,14 @@ for a file to visit if current buffer is not visiting a file."
         (find-alternate-file (sudo-edit-filename filename user))
         (goto-char position)))))
 
+;;;###autoload
+(defun sudo-edit-find-file (filename)
+  "Edit FILENAME as another user, by default `sudo-edit-user'."
+  (interactive
+   (read-file-name (format "Find file (as \"%s\"): " sudo-edit-user)))
+  (cl-assert (not (string-blank-p sudo-edit-user)) nil "User must not be a empty string")
+  (find-file (sudo-edit-filename filename sudo-edit-user)))
+
 (define-obsolete-function-alias 'sudo-edit-current-file 'sudo-edit)
 
 (provide 'sudo-edit)


### PR DESCRIPTION
Just a wrapper around find-file. 
Works as a non-interactive version too - this was the main reason for making the PR since I couldn't find a way to use sudo-edit in external lisp code.

Thanks.